### PR TITLE
feat: Cloudflare Workers (*.workers.dev) を開発無料枠に追加

### DIFF
--- a/referers.json
+++ b/referers.json
@@ -41,6 +41,7 @@
   "https://*.preview.app.github.dev",
   "https://*.pages.dev",
   "https://*.*.pages.dev",
+  "https://*.workers.dev",
   "https://maplibre.org",
   "https://*.cloudfront.net"
 ]

--- a/referers.json
+++ b/referers.json
@@ -42,6 +42,7 @@
   "https://*.pages.dev",
   "https://*.*.pages.dev",
   "https://*.workers.dev",
+  "https://*.*.workers.dev",
   "https://maplibre.org",
   "https://*.cloudfront.net"
 ]


### PR DESCRIPTION
## Summary

- `https://*.workers.dev` と `https://*.*.workers.dev` を開発無料枠のリファラーホワイトリストに追加

Cloudflare Pages (`*.pages.dev`, `*.*.pages.dev`) は既に登録済みですが、Cloudflare Workers (`*.workers.dev`) が未登録でした。

## Test plan

- [x] JSON が valid であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)